### PR TITLE
Update Chinese BBS RSS url

### DIFF
--- a/admin/lib/data/infoData.json
+++ b/admin/lib/data/infoData.json
@@ -22,7 +22,7 @@
         },
         "zh-cn": {
             "link": "https://bbs.iobroker.cn",
-            "feeds": ["https://bbs.iobroker.cn/?mod=rss"]
+            "feeds": ["https://bbs.iobroker.cn/latest.rss"]
         }
     },
     "supportedNewsLang": ["de", "en", "ru", "zh-cn"],


### PR DESCRIPTION
Hi @ldittmar81  
Chinese BBS has changed from discuz to discourse.
So the RSS url need update too.

I created a patch, but it seems not working.
Need you help....